### PR TITLE
Added User 조회 및 업데이트 API, Error JSON Response 

### DIFF
--- a/src/main/java/com/donghun/reactiveblog/config/error/GlobalErrorAttributes.java
+++ b/src/main/java/com/donghun/reactiveblog/config/error/GlobalErrorAttributes.java
@@ -1,0 +1,28 @@
+package com.donghun.reactiveblog.config.error;
+
+import com.donghun.reactiveblog.config.exception.GlobalException;
+import org.springframework.boot.web.reactive.error.DefaultErrorAttributes;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+import java.util.Map;
+
+@Component
+public class GlobalErrorAttributes extends DefaultErrorAttributes {
+    @Override
+    public Map<String, Object> getErrorAttributes(ServerRequest request, boolean includeStackTrace) {
+        Map<String, Object> map = super.getErrorAttributes(request, includeStackTrace);
+
+        if (getError(request) instanceof GlobalException) {
+            GlobalException ex = (GlobalException) getError(request);
+            map.put("exception", ex.getClass().getSimpleName());
+            map.put("message", ex.getMessage());
+            map.put("status", ex.getStatus().value());
+            map.put("error", ex.getStatus().getReasonPhrase());
+
+            return map;
+        }
+
+        return map;
+    }
+}

--- a/src/main/java/com/donghun/reactiveblog/config/error/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/com/donghun/reactiveblog/config/error/GlobalErrorWebExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.donghun.reactiveblog.config.error;
+
+import org.springframework.boot.autoconfigure.web.ResourceProperties;
+import org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.*;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Order(-2)
+public class GlobalErrorWebExceptionHandler extends AbstractErrorWebExceptionHandler {
+
+    public GlobalErrorWebExceptionHandler(GlobalErrorAttributes g, ApplicationContext applicationContext,
+                                          ServerCodecConfigurer serverCodecConfigurer) {
+        super(g, new ResourceProperties(), applicationContext);
+        super.setMessageWriters(serverCodecConfigurer.getWriters());
+        super.setMessageReaders(serverCodecConfigurer.getReaders());
+    }
+
+    @Override
+    protected RouterFunction<ServerResponse> getRoutingFunction(final ErrorAttributes errorAttributes) {
+        return RouterFunctions.route(RequestPredicates.all(), this::renderErrorResponse);
+    }
+
+    private Mono<ServerResponse> renderErrorResponse(final ServerRequest request) {
+
+        final Map<String, Object> errorPropertiesMap = getErrorAttributes(request, false);
+
+        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> bodyMap = new HashMap<>();
+        bodyMap.put("body", errorPropertiesMap);
+        map.put("errors", bodyMap);
+
+        return ServerResponse.status((Integer) errorPropertiesMap.get("status"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(map));
+    }
+
+}

--- a/src/main/java/com/donghun/reactiveblog/config/exception/GlobalException.java
+++ b/src/main/java/com/donghun/reactiveblog/config/exception/GlobalException.java
@@ -1,0 +1,15 @@
+package com.donghun.reactiveblog.config.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class GlobalException extends ResponseStatusException {
+
+    public GlobalException(HttpStatus status, String message) {
+        super(status, message);
+    }
+
+    public GlobalException(HttpStatus status, String message, Throwable e) {
+        super(status, message, e);
+    }
+}

--- a/src/main/java/com/donghun/reactiveblog/config/vaild/SomeUtilClass.java
+++ b/src/main/java/com/donghun/reactiveblog/config/vaild/SomeUtilClass.java
@@ -1,0 +1,5 @@
+package com.donghun.reactiveblog.config.vaild;
+
+public class SomeUtilClass {
+    public static final String UUID_PATTERN = "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$";
+}

--- a/src/main/java/com/donghun/reactiveblog/domain/Fallow.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/Fallow.java
@@ -20,5 +20,5 @@ public class Fallow {
 
     private String fallow;
 
-    private String fallower;
+    private String fallowing;
 }

--- a/src/main/java/com/donghun/reactiveblog/domain/dto/UserDTO.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/dto/UserDTO.java
@@ -1,0 +1,39 @@
+package com.donghun.reactiveblog.domain.dto;
+
+import com.donghun.reactiveblog.config.vaild.SomeUtilClass;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Pattern;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-07
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDTO {
+
+    @Pattern(regexp = SomeUtilClass.UUID_PATTERN, message = "id must be uuid")
+    private String id;
+
+    @Email(message = "유효한 이메일이 아닙니다. 이메일 형식인지 확인해주시길 바랍니다.")
+    private String email;
+
+    @Length(max = 30, message = "유저네임은 30자 미만으로 설정하시길 바랍니다.")
+    private String username;
+
+    @URL(message = "올바른 이미지 URL이 아닙니다.")
+    private String image;
+
+    @Length(max = 150, message = "bio는 150자 이내로 설정하시길 바랍니다.")
+    private String bio;
+
+}

--- a/src/main/java/com/donghun/reactiveblog/domain/vo/CurrentUserVO.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/vo/CurrentUserVO.java
@@ -1,0 +1,16 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import com.donghun.reactiveblog.domain.dto.UserDTO;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-07
+ */
+@Getter
+@Setter
+public class CurrentUserVO {
+
+    private UserDTO user;
+}

--- a/src/main/java/com/donghun/reactiveblog/domain/vo/ErrorStatusVO.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/vo/ErrorStatusVO.java
@@ -1,0 +1,25 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-07
+ */
+@ToString
+@Getter
+public class ErrorStatusVO {
+    private Map<String, Object> errors;
+
+    public ErrorStatusVO(List<String> messages) {
+        errors = new HashMap<>();
+        Map<String, Object> map = new HashMap<>();
+        map.put("body", messages);
+        errors.put("errors", map);
+    }
+}

--- a/src/main/java/com/donghun/reactiveblog/handler/UserHandler.java
+++ b/src/main/java/com/donghun/reactiveblog/handler/UserHandler.java
@@ -1,9 +1,9 @@
 package com.donghun.reactiveblog.handler;
 
-import com.donghun.reactiveblog.repository.UserRepository;
 import com.donghun.reactiveblog.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.server.ServerHttpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
@@ -17,17 +17,32 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class UserHandler {
 
+    private static final Logger logger = LoggerFactory.getLogger(UserHandler.class);
+
     private final UserService userService;
 
     public Mono<ServerResponse> signUp(ServerRequest request) {
+        logger.info("sing up Handler Accessed");
         return userService.signUpProcessLogic(request);
     }
 
     public Mono<ServerResponse> login(ServerRequest request) {
+        logger.info("Login Handler Accessed");
         return userService.loginProcessLogic(request);
     }
 
     public Mono<ServerResponse> logout(ServerRequest request) {
+        logger.info("Logout Handler Accessed");
         return  userService.logoutProcessLogic(request);
+    }
+
+    public Mono<ServerResponse> currentUser(ServerRequest request) {
+        logger.info("Current User Handler Accessed");
+        return userService.getCurrentUserProcessLogic(request);
+    }
+
+    public Mono<ServerResponse> updateUser(ServerRequest request) {
+        logger.info("Update User Handler Accessed");
+        return userService.updateUserProcessLogic(request);
     }
 }

--- a/src/main/java/com/donghun/reactiveblog/route/ServerRouter.java
+++ b/src/main/java/com/donghun/reactiveblog/route/ServerRouter.java
@@ -25,6 +25,9 @@ public class ServerRouter {
         return RouterFunctions.nest(path("/api/users"),
                 route(POST("/").and(contentType(MediaType.APPLICATION_JSON)), userHandler::signUp)
                 .andRoute(POST("/login").and(contentType(MediaType.APPLICATION_JSON)), userHandler::login)
-                .andRoute(POST("/logout"), userHandler::logout));
+                .andRoute(POST("/logout"), userHandler::logout))
+                .andNest(path("/api/user"),
+                        route(GET("/"), userHandler::currentUser)
+                        .andRoute(PUT("/").and(contentType(MediaType.APPLICATION_JSON)), userHandler::updateUser));
     }
 }

--- a/src/test/java/com/donghun/reactiveblog/domain/FallowTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/FallowTest.java
@@ -19,18 +19,18 @@ public class FallowTest {
 
         // given
         String fallow = "Test_USER_A";
-        String fallower = "TEST_USER_B";
+        String fallowing = "TEST_USER_B";
 
         // when
         Fallow fallow1 = Fallow.builder()
                     .id(UUID.randomUUID().toString())
                     .fallow(fallow)
-                    .fallower(fallower)
+                    .fallowing(fallowing)
                     .build();
 
         // then
         then(fallow1).isNotNull();
         then(fallow1.getFallow()).isEqualTo(fallow);
-        then(fallow1.getFallower()).isEqualTo(fallower);
+        then(fallow1.getFallowing()).isEqualTo(fallowing);
     }
 }

--- a/src/test/java/com/donghun/reactiveblog/domain/dto/UserDTOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/dto/UserDTOTest.java
@@ -1,0 +1,45 @@
+package com.donghun.reactiveblog.domain.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-07
+ */
+class UserDTOTest {
+
+    @Test
+    @DisplayName("UserDTO 객체 생성 테스트")
+    public void userVOCreateTest() {
+
+        // given
+        String id = UUID.randomUUID().toString();
+        String username = "testName";
+        String email = "test@Email.com";
+        String image = "normal image";
+        String bio = "I'm Hello World";
+
+        // when
+        UserDTO userDTOTest = UserDTO.builder()
+                            .id(id)
+                            .username(username)
+                            .email(email)
+                            .image(image)
+                            .bio(bio)
+                            .build();
+
+        // then
+        then(userDTOTest).isNotNull();
+        then(userDTOTest.getId()).isEqualTo(id);
+        then(userDTOTest.getUsername()).isEqualTo(username);
+        then(userDTOTest.getEmail()).isEqualTo(email);
+        then(userDTOTest.getImage()).isEqualTo(image);
+        then(userDTOTest.getBio()).isEqualTo(bio);
+    }
+
+}

--- a/src/test/java/com/donghun/reactiveblog/domain/vo/CurrentUserVOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/vo/CurrentUserVOTest.java
@@ -1,0 +1,25 @@
+package com.donghun.reactiveblog.domain.vo;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-06
+ */
+class CurrentUserVOTest {
+
+    @Test
+    @DisplayName("CurrentUserVO 객체 생성 테스트")
+    public void currentUserVOCreateTest() {
+
+        // given, when
+        CurrentUserVO userVO = new CurrentUserVO();
+
+        // then
+        then(userVO).isNotNull();
+    }
+}

--- a/src/test/java/com/donghun/reactiveblog/domain/vo/ErrorStatusVOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/vo/ErrorStatusVOTest.java
@@ -1,0 +1,30 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-09
+ */
+class ErrorStatusVOTest {
+
+    @Test
+    @DisplayName("ErrorStatusVO 객체 생성 테스트")
+    public void createErrorStatusVOTest() {
+
+        // given
+        List<String> messages = Collections.singletonList("Error Message");
+
+        // when
+        ErrorStatusVO errorStatusVO = new ErrorStatusVO(messages);
+
+        // then
+        then(errorStatusVO).isNotNull();
+    }
+}

--- a/src/test/java/com/donghun/reactiveblog/domain/vo/StatusVOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/vo/StatusVOTest.java
@@ -6,6 +6,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+/**
+ * @author donghL-dev
+ * @since  2019-12-06
+ */
 class StatusVOTest {
 
     @Test

--- a/src/test/java/com/donghun/reactiveblog/domain/vo/SuccessVOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/vo/SuccessVOTest.java
@@ -6,6 +6,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+/**
+ * @author donghL-dev
+ * @since  2019-12-06
+ */
 class SuccessVOTest {
 
     @Test

--- a/src/test/java/com/donghun/reactiveblog/handler/BaseHandlerTest.java
+++ b/src/test/java/com/donghun/reactiveblog/handler/BaseHandlerTest.java
@@ -1,0 +1,57 @@
+package com.donghun.reactiveblog.handler;
+
+import com.donghun.reactiveblog.config.auth.SecurityConstants;
+import com.donghun.reactiveblog.domain.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-09
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+public class BaseHandlerTest {
+
+    @Value("${springbootwebfluxjjwt.jjwt.secret}")
+    private String secret;
+
+    @Autowired
+    public WebTestClient webTestClient;
+
+    public String generateToken(User user) {
+        List<String> roles = Stream.of(new SimpleGrantedAuthority("USER")).map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        byte[] signingKey = secret.getBytes();
+
+        return Jwts.builder()
+                .signWith(SignatureAlgorithm.HS512, signingKey)
+                .setHeaderParam("typ", SecurityConstants.TOKEN_TYPE)
+                .setIssuer(SecurityConstants.TOKEN_ISSUER)
+                .setAudience(SecurityConstants.TOKEN_AUDIENCE)
+                .setSubject("Reactive-Blog JWT Token")
+                .claim("idx", user.getId())
+                .claim("email", user.getEmail())
+                .claim("userName", user.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 100000000))
+                .claim("role", roles)
+                .compact();
+    }
+}


### PR DESCRIPTION
- 현재 유저를 조회 및 업데이트를 하는 `API` 추가. (#11)

- `API` 요청의 반환 값으로 에러를 반환할 때 `JSON` 포맷으로 반환하도록 로직 작성. (#12)

- 원할한 테스트 작업을 위해서 `BaseHandlerTest` 클래스 작성.

- 원할한 디버깅을 위해서 `UserHandler`에 `Logger`를 추가.

- `API` 요청을 위해서 `UserDTO`, `CurrentUserVO`, `ErrorStatusVO` 클래스 작성.