### PR TITLE
Added Comment 관련 API 작성 

### DIFF
--- a/src/main/java/com/donghun/reactiveblog/AppRunner.java
+++ b/src/main/java/com/donghun/reactiveblog/AppRunner.java
@@ -3,10 +3,7 @@ package com.donghun.reactiveblog;
 import com.donghun.reactiveblog.domain.Article;
 import com.donghun.reactiveblog.domain.User;
 import com.donghun.reactiveblog.domain.vo.ProfileBodyVO;
-import com.donghun.reactiveblog.repository.ArticleRepository;
-import com.donghun.reactiveblog.repository.FollowRepository;
-import com.donghun.reactiveblog.repository.TokenRepository;
-import com.donghun.reactiveblog.repository.UserRepository;
+import com.donghun.reactiveblog.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -36,6 +33,8 @@ public class AppRunner implements CommandLineRunner {
 
     private final ArticleRepository articleRepository;
 
+    private final CommentRepository commentRepository;
+
     private final PasswordEncoder passwordEncoder;
 
     @Override
@@ -52,6 +51,7 @@ public class AppRunner implements CommandLineRunner {
 
         tokenRepository.deleteAll().subscribe();
         followRepository.deleteAll().subscribe();
+        commentRepository.deleteAll().subscribe();
     }
 
     public User createUser(int index) {

--- a/src/main/java/com/donghun/reactiveblog/domain/Comment.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/Comment.java
@@ -1,5 +1,8 @@
 package com.donghun.reactiveblog.domain;
 
+import com.donghun.reactiveblog.domain.vo.ProfileBodyVO;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -22,11 +25,14 @@ public class Comment {
 
     private String body;
 
-    private String author;
+    private ProfileBodyVO author;
 
+    @JsonIgnore
     private String slug;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/donghun/reactiveblog/domain/dto/CommentDTO.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/dto/CommentDTO.java
@@ -1,0 +1,20 @@
+package com.donghun.reactiveblog.domain.dto;
+
+import lombok.*;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+@Getter @Setter @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentDTO {
+
+    @NotBlank(message = "내용이 비어있습니다.")
+    @Length(max = 500, min = 1, message = "내용은 1~500 사이로 설정하시길 바랍니다.")
+    private String body;
+}

--- a/src/main/java/com/donghun/reactiveblog/domain/vo/CommentPostVO.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/vo/CommentPostVO.java
@@ -1,0 +1,15 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import com.donghun.reactiveblog.domain.dto.CommentDTO;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+@Getter @Setter
+public class CommentPostVO {
+
+    private CommentDTO comment;
+}

--- a/src/main/java/com/donghun/reactiveblog/domain/vo/CommentVO.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/vo/CommentVO.java
@@ -1,0 +1,19 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import com.donghun.reactiveblog.domain.Comment;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+@Getter @Setter
+public class CommentVO {
+
+    private Comment comment;
+
+    public CommentVO(Comment comment) {
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/donghun/reactiveblog/domain/vo/CommentsVO.java
+++ b/src/main/java/com/donghun/reactiveblog/domain/vo/CommentsVO.java
@@ -1,0 +1,22 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import com.donghun.reactiveblog.domain.Comment;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-14
+ */
+@Getter
+@Setter
+public class CommentsVO {
+
+    private List<Comment> comments;
+
+    public CommentsVO(List<Comment> comments) {
+        this.comments = comments;
+    }
+}

--- a/src/main/java/com/donghun/reactiveblog/handler/CommentHandler.java
+++ b/src/main/java/com/donghun/reactiveblog/handler/CommentHandler.java
@@ -1,0 +1,38 @@
+package com.donghun.reactiveblog.handler;
+
+import com.donghun.reactiveblog.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+@Component
+@RequiredArgsConstructor
+public class CommentHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(CommentHandler.class);
+
+    private final CommentService commentService;
+
+    public Mono<ServerResponse> postComment(ServerRequest request) {
+        logger.info("Post Comment Handler Accessed");
+        return commentService.postCommentProcessLogic(request);
+    }
+
+    public Mono<ServerResponse> getComments(ServerRequest request) {
+        logger.info("Get Comments Handler Accessed");
+        return commentService.getCommentsProcessLogic(request);
+    }
+
+    public Mono<ServerResponse> deleteComment(ServerRequest request) {
+        logger.info("Delete Comment Handler Accessed");
+        return commentService.deleteCommentProcessLogic(request);
+    }
+}

--- a/src/main/java/com/donghun/reactiveblog/repository/CommentRepository.java
+++ b/src/main/java/com/donghun/reactiveblog/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.donghun.reactiveblog.repository;
 
 import com.donghun.reactiveblog.domain.Comment;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -9,5 +10,5 @@ import reactor.core.publisher.Mono;
  * @since  2019-12-02
  */
 public interface CommentRepository extends ReactiveMongoRepository<Comment, String> {
-    Mono<Comment> findByBodyAndAuthorAndSlug(String body, String slug, String author);
+    Flux<Comment> findBySlug(String slug);
 }

--- a/src/main/java/com/donghun/reactiveblog/route/ServerRouter.java
+++ b/src/main/java/com/donghun/reactiveblog/route/ServerRouter.java
@@ -1,6 +1,7 @@
 package com.donghun.reactiveblog.route;
 
 import com.donghun.reactiveblog.handler.ArticleHandler;
+import com.donghun.reactiveblog.handler.CommentHandler;
 import com.donghun.reactiveblog.handler.ProfileHandler;
 import com.donghun.reactiveblog.handler.UserHandler;
 import org.springframework.context.annotation.Bean;
@@ -42,7 +43,7 @@ public class ServerRouter {
     }
 
     @Bean
-    public RouterFunction<ServerResponse> articleRoutes(ArticleHandler articleHandler) {
+    public RouterFunction<ServerResponse> articleRoutes(ArticleHandler articleHandler, CommentHandler commentHandler) {
         return RouterFunctions.nest(path("/api/articles"),
                 route(GET("/"), articleHandler::getArticles)
                 .andRoute(GET("/feed"), articleHandler::getFeedArticles)
@@ -50,5 +51,13 @@ public class ServerRouter {
                 .andRoute(POST("/").and(contentType(MediaType.APPLICATION_JSON)), articleHandler::postArticle)
                 .andRoute(PUT("/{slug}").and(contentType(MediaType.APPLICATION_JSON)), articleHandler::putArticle)
                 .andRoute(DELETE("/{slug}"), articleHandler::deleteArticle));
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> commentRoutes(CommentHandler commentHandler) {
+        return RouterFunctions.nest(path("/api/articles/{slug}/comments"),
+                route(POST("/").and(contentType(MediaType.APPLICATION_JSON)), commentHandler::postComment)
+                .andRoute(GET("/"), commentHandler::getComments)
+                .andRoute(DELETE("/{id}"), commentHandler::deleteComment));
     }
 }

--- a/src/main/java/com/donghun/reactiveblog/service/ArticleService.java
+++ b/src/main/java/com/donghun/reactiveblog/service/ArticleService.java
@@ -194,9 +194,8 @@ public class ArticleService {
         return articleRepository.findBySlug(request.pathVariable("slug"))
                 .flatMap(article -> {
                     if(article.getAuthor().getEmail().equals(jwtResolver.getUserByToken(request))) {
-                        articleRepository.delete(article).subscribe();
-                        return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).body(Mono
-                                .just(new SuccessVO(new StatusVO())), SuccessVO.class);
+                        return articleRepository.delete(article).then(ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).body(Mono
+                                .just(new SuccessVO(new StatusVO())), SuccessVO.class));
                     } else {
                         return ServerResponse.status(401).contentType(MediaType.APPLICATION_JSON).body(
                                 Mono.just(new ErrorStatusVO(Collections.singletonList("You didn't write this article, " +

--- a/src/main/java/com/donghun/reactiveblog/service/CommentService.java
+++ b/src/main/java/com/donghun/reactiveblog/service/CommentService.java
@@ -1,0 +1,103 @@
+package com.donghun.reactiveblog.service;
+
+import com.donghun.reactiveblog.config.auth.JwtResolver;
+import com.donghun.reactiveblog.domain.Comment;
+import com.donghun.reactiveblog.domain.Follow;
+import com.donghun.reactiveblog.domain.vo.*;
+import com.donghun.reactiveblog.repository.ArticleRepository;
+import com.donghun.reactiveblog.repository.CommentRepository;
+import com.donghun.reactiveblog.repository.FollowRepository;
+import com.donghun.reactiveblog.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final UserRepository userRepository;
+
+    private final CommentRepository commentRepository;
+
+    private final ArticleRepository articleRepository;
+
+    private final FollowRepository followRepository;
+
+    private final JwtResolver jwtResolver;
+
+    public Mono<ServerResponse> postCommentProcessLogic(ServerRequest request) {
+        return request.bodyToMono(CommentPostVO.class).map(CommentPostVO::getComment)
+                .flatMap(commentDTO -> userRepository.findByEmail(jwtResolver.getUserByToken(request))
+                        .flatMap(user -> articleRepository.findBySlug(request.pathVariable("slug"))
+                                .flatMap(article -> commentRepository.save(Comment.builder()
+                                        .id(UUID.randomUUID().toString())
+                                        .body(commentDTO.getBody())
+                                        .author(new ProfileBodyVO(user, false))
+                                        .slug(article.getSlug())
+                                        .createdAt(LocalDateTime.now())
+                                        .updatedAt(LocalDateTime.now())
+                                        .build()))
+                                        .flatMap(comment -> ServerResponse.created(request.uri()).contentType(MediaType.APPLICATION_JSON)
+                                                .body(Mono.just(new CommentVO(comment)), CommentVO.class))
+                                .switchIfEmpty(ServerResponse.badRequest().contentType(MediaType.APPLICATION_JSON).body(
+                                        Mono.just(new ErrorStatusVO(Collections.singletonList("Article does not exist")).getErrors()), Map.class)))
+                        .switchIfEmpty(ServerResponse.badRequest().contentType(MediaType.APPLICATION_JSON).body(
+                                Mono.just(new ErrorStatusVO(Collections.singletonList("User does not exist")).getErrors()), Map.class)));
+    }
+
+    public Mono<ServerResponse> getCommentsProcessLogic(ServerRequest request) {
+        return commentRepository.findBySlug(request.pathVariable("slug"))
+                .flatMap(comment -> {
+                    String currentUser = request.headers().header("Authorization").size() == 0 ?
+                            "Nullable@email.com" : jwtResolver.getUserByToken(request);
+                    Mono<Follow> followMono = followRepository.findByFollowAndFollowing(comment.getAuthor().
+                            getEmail(), currentUser).switchIfEmpty(Mono.just(Follow.builder().follow("Invalid Follow").build()));
+
+                    return followMono.flatMap(follow -> {
+                        if(follow.getFollow().equals("Invalid Follow")) {
+                            comment.getAuthor().setFallowing(false);
+                        } else {
+                            comment.getAuthor().setFallowing(true);
+                        }
+                        return Mono.just(comment);
+                    });
+                }).collectList().flatMap(comments ->
+                        ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
+                                .body(Mono.just(new CommentsVO(comments)), CommentsVO.class))
+                .switchIfEmpty(ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
+                        .body(Mono.just(new CommentsVO(Collections.emptyList())), CommentsVO.class));
+    }
+
+    public Mono<ServerResponse> deleteCommentProcessLogic(ServerRequest request) {
+        return articleRepository.findBySlug(request.pathVariable("slug"))
+                .flatMap(article -> commentRepository.findById(request.pathVariable("id"))
+                        .flatMap(comment -> {
+                            if(comment.getAuthor().getEmail().equals(jwtResolver.getUserByToken(request))) {
+                                return commentRepository.delete(comment).then(ServerResponse.ok()
+                                        .contentType(MediaType.APPLICATION_JSON).body(Mono.just(new SuccessVO(
+                                                new StatusVO())), SuccessVO.class));
+                            } else {
+                                return ServerResponse.status(401).contentType(MediaType.APPLICATION_JSON).body(
+                                        Mono.just(new ErrorStatusVO(Collections.singletonList("You didn't write this article, " +
+                                                "only the author can delete the article.")).getErrors()), Map.class);
+                            }
+                        })
+                        .switchIfEmpty(ServerResponse.badRequest().contentType(MediaType.APPLICATION_JSON).body(
+                                Mono.just(new ErrorStatusVO(Collections.singletonList("Comment does not exist")).getErrors()), Map.class)))
+                .switchIfEmpty(ServerResponse.badRequest().contentType(MediaType.APPLICATION_JSON).body(
+                        Mono.just(new ErrorStatusVO(Collections.singletonList("Article does not exist")).getErrors()), Map.class));
+    }
+}

--- a/src/main/java/com/donghun/reactiveblog/service/UserService.java
+++ b/src/main/java/com/donghun/reactiveblog/service/UserService.java
@@ -102,9 +102,9 @@ public class UserService {
     }
 
     public Mono<ServerResponse> logoutProcessLogic(ServerRequest request) {
-        tokenRepository.findByEmail(jwtResolver.getUserByToken(request)).map(Token::getId).flatMap(tokenRepository::deleteById).subscribe();
-        return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
-                .body(Mono.just(new SuccessVO(new StatusVO())), SuccessVO.class);
+        return tokenRepository.findByEmail(jwtResolver.getUserByToken(request)).map(Token::getId)
+                .flatMap(tokenRepository::deleteById).then(ServerResponse.ok()
+                        .contentType(MediaType.APPLICATION_JSON).body(Mono.just(new SuccessVO(new StatusVO())), SuccessVO.class));
     }
 
     public Mono<ServerResponse> getCurrentUserProcessLogic(ServerRequest request) {

--- a/src/test/java/com/donghun/reactiveblog/domain/CommentTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/CommentTest.java
@@ -1,5 +1,6 @@
 package com.donghun.reactiveblog.domain;
 
+import com.donghun.reactiveblog.domain.vo.ProfileBodyVO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +21,8 @@ public class CommentTest {
 
         // given
         String body = "게시글이 멋집니다.";
-        String author = "Test_USER";
+        ProfileBodyVO author = new ProfileBodyVO(User.builder()
+                .username("test_user").bio("bio").email("email").image("").build(), false);
         String slug = "Hello-World";
 
         // when

--- a/src/test/java/com/donghun/reactiveblog/domain/dto/CommentDTOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/dto/CommentDTOTest.java
@@ -1,0 +1,29 @@
+package com.donghun.reactiveblog.domain.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+class CommentDTOTest {
+
+    @Test
+    @DisplayName("CommentDTO 객체를 생성하는 테스트")
+    public void commentDTOCreateTest() {
+
+        // given
+        String body = "테스트 내용입니다.";
+
+        // when
+        CommentDTO commentDTO = CommentDTO.builder().body(body).build();
+
+        // then
+        then(commentDTO).isNotNull();
+        then(commentDTO.getBody()).isEqualTo(body);
+    }
+
+}

--- a/src/test/java/com/donghun/reactiveblog/domain/vo/CommentPostVOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/vo/CommentPostVOTest.java
@@ -1,0 +1,25 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+class CommentPostVOTest {
+
+    @Test
+    @DisplayName("CommentPostVO 객체를 생성하는 테스트")
+    public void commentPostVOCreateTest() {
+
+        // given, when
+        CommentPostVO commentPostVO = new CommentPostVO();
+
+        // then
+        then(commentPostVO).isNotNull();
+
+    }
+}

--- a/src/test/java/com/donghun/reactiveblog/domain/vo/CommentVOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/vo/CommentVOTest.java
@@ -1,0 +1,34 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import com.donghun.reactiveblog.domain.Comment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+class CommentVOTest {
+
+    @Test
+    @DisplayName("CommentVO 객체를 생성하는 테스트")
+    public void commentVOCreateTest() {
+
+        // given
+        Comment comment = Comment.builder()
+                .id(UUID.randomUUID().toString())
+                .body("테스트 댓글").build();
+
+        // when
+        CommentVO commentVO = new CommentVO(comment);
+
+        // then
+        then(commentVO).isNotNull();
+        then(commentVO.getComment()).isEqualTo(comment);
+    }
+
+}

--- a/src/test/java/com/donghun/reactiveblog/domain/vo/CommentsVOTest.java
+++ b/src/test/java/com/donghun/reactiveblog/domain/vo/CommentsVOTest.java
@@ -1,0 +1,33 @@
+package com.donghun.reactiveblog.domain.vo;
+
+import com.donghun.reactiveblog.domain.Comment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-14
+ */
+class CommentsVOTest {
+
+
+    @Test
+    @DisplayName("CommentsVO 객체 생성 테스트")
+    public void commentVOCreateTest() {
+
+        // given
+        List<Comment> comments = Arrays.asList(Comment.builder().body("테스트 댓글").build());
+
+        // when
+        CommentsVO commentsVO = new CommentsVO(comments);
+
+        // then
+        then(commentsVO).isNotNull();
+        then(commentsVO.getComments()).isEqualTo(comments);
+    }
+}

--- a/src/test/java/com/donghun/reactiveblog/handler/ArticleHandlerTest.java
+++ b/src/test/java/com/donghun/reactiveblog/handler/ArticleHandlerTest.java
@@ -51,9 +51,9 @@ class ArticleHandlerTest extends BaseHandlerTest {
 
     @BeforeEach
     public void init() {
-        userRepository.deleteAll();
-        tokenRepository.deleteAll();
-        articleRepository.deleteAll();
+        userRepository.deleteAll().subscribe();
+        tokenRepository.deleteAll().subscribe();
+        articleRepository.deleteAll().subscribe();
 
     }
 

--- a/src/test/java/com/donghun/reactiveblog/handler/CommentHandlerTest.java
+++ b/src/test/java/com/donghun/reactiveblog/handler/CommentHandlerTest.java
@@ -1,0 +1,211 @@
+package com.donghun.reactiveblog.handler;
+
+import com.donghun.reactiveblog.domain.Article;
+import com.donghun.reactiveblog.domain.Comment;
+import com.donghun.reactiveblog.domain.Token;
+import com.donghun.reactiveblog.domain.User;
+import com.donghun.reactiveblog.domain.dto.CommentDTO;
+import com.donghun.reactiveblog.domain.vo.CommentPostVO;
+import com.donghun.reactiveblog.domain.vo.ProfileBodyVO;
+import com.donghun.reactiveblog.repository.ArticleRepository;
+import com.donghun.reactiveblog.repository.CommentRepository;
+import com.donghun.reactiveblog.repository.TokenRepository;
+import com.donghun.reactiveblog.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author donghL-dev
+ * @since  2019-12-13
+ */
+class CommentHandlerTest extends BaseHandlerTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    public void init() {
+        userRepository.deleteAll().subscribe();
+        tokenRepository.deleteAll().subscribe();
+        articleRepository.deleteAll().subscribe();
+        commentRepository.deleteAll().subscribe();
+    }
+
+    @Test
+    @DisplayName("Comment 를 생성하는 API 테스트")
+    public void postCommentRouteTest() {
+
+        User user = User.builder()
+                .id(UUID.randomUUID().toString())
+                .username("test_user15")
+                .email("test_user15@email.com")
+                .password(passwordEncoder.encode("testPassword123445"))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        Mono.just(user).flatMap(userRepository::save).subscribe();
+
+        String token = generateToken(user);
+        Mono.just(Token.builder().id(UUID.randomUUID().toString()).email(user.getEmail()).token(token).build())
+                .flatMap(tokenRepository::save).subscribe();
+
+        Article article = Article.builder()
+                .id(UUID.randomUUID().toString())
+                .slug("Create-Comment-Post-Test")
+                .title("Create Comment Post Test")
+                .description("it is Hello World ")
+                .body("Hello World Content ")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .favorites(Collections.emptySet())
+                .tags(Collections.emptySet())
+                .favoritesCount(0)
+                .author(new ProfileBodyVO(user, false))
+                .build();
+
+        Mono.just(article).flatMap(articleRepository::save).subscribe();
+
+        CommentDTO commentDTO = CommentDTO.builder().body("테스트 내용1").build();
+        CommentPostVO commentPostVO = new CommentPostVO();
+        commentPostVO.setComment(commentDTO);
+
+        webTestClient.post()
+                .uri("/api/articles/" + article.getSlug() + "/comments")
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .body(Mono.just(commentPostVO), CommentPostVO.class)
+                .exchange()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectStatus()
+                .isCreated();
+
+        Flux<Comment> commentFlux = commentRepository.findBySlug(article.getSlug());
+
+        StepVerifier.create(commentFlux)
+                .assertNext(comment -> then(comment.getBody()).isEqualTo(commentDTO.getBody()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Comment 를 조회하는 API 테스트")
+    public void getCommentsRouteTest() {
+        User user = User.builder()
+                .id(UUID.randomUUID().toString())
+                .username("test_user15")
+                .email("test_user15@email.com")
+                .password(passwordEncoder.encode("testPassword123445"))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        Mono.just(user).flatMap(userRepository::save).subscribe();
+
+        String token = generateToken(user);
+        Mono.just(Token.builder().id(UUID.randomUUID().toString()).email(user.getEmail()).token(token).build())
+                .flatMap(tokenRepository::save).subscribe();
+
+        Article article = Article.builder()
+                .id(UUID.randomUUID().toString())
+                .slug("Create-Comment-Post-Test")
+                .title("Create Comment Post Test")
+                .description("it is Hello World ")
+                .body("Hello World Content ")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .favorites(Collections.emptySet())
+                .tags(Collections.emptySet())
+                .favoritesCount(0)
+                .author(new ProfileBodyVO(user, false))
+                .build();
+
+        Mono.just(article).flatMap(articleRepository::save).subscribe();
+
+        webTestClient.get()
+                .uri("/api/articles/" + article.getSlug() + "/comments")
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .exchange()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectStatus()
+                .isOk();
+    }
+
+    @Test
+    @DisplayName("Comment를 삭제하는 API 테스트")
+    public void deleteCommentRouteTest() {
+        User user = User.builder()
+                .id(UUID.randomUUID().toString())
+                .username("test_user16")
+                .email("test_user16@email.com")
+                .password(passwordEncoder.encode("testPassword123445"))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        Mono.just(user).flatMap(userRepository::save).subscribe();
+
+        String token = generateToken(user);
+        Mono.just(Token.builder().id(UUID.randomUUID().toString()).email(user.getEmail()).token(token).build())
+                .flatMap(tokenRepository::save).subscribe();
+
+        Article article = Article.builder()
+                .id(UUID.randomUUID().toString())
+                .slug("Create-Comment-Post-Test6")
+                .title("Create Comment Post Test6")
+                .description("it is Hello World ")
+                .body("Hello World Content ")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .favorites(Collections.emptySet())
+                .tags(Collections.emptySet())
+                .favoritesCount(0)
+                .author(new ProfileBodyVO(user, false))
+                .build();
+
+        Mono.just(article).flatMap(articleRepository::save).subscribe();
+
+        Comment comment = Comment.builder()
+                .id(UUID.randomUUID().toString())
+                .body("곧 삭제될 댓글")
+                .author(new ProfileBodyVO(user, false))
+                .slug(article.getSlug())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now()).build();
+
+        Mono.just(comment).flatMap(commentRepository::save).subscribe();
+
+        webTestClient.delete()
+                .uri("/api/articles/" + article.getSlug() + "/comments/" + comment.getId())
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .exchange()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectStatus()
+                .isOk();
+    }
+
+}

--- a/src/test/java/com/donghun/reactiveblog/handler/ProfileHandlerTest.java
+++ b/src/test/java/com/donghun/reactiveblog/handler/ProfileHandlerTest.java
@@ -42,8 +42,8 @@ public class ProfileHandlerTest extends BaseHandlerTest {
 
     @BeforeEach
     public void init() {
-        userRepository.deleteAll();
-        tokenRepository.deleteAll();
+        userRepository.deleteAll().subscribe();
+        tokenRepository.deleteAll().subscribe();
     }
 
     @Test
@@ -165,9 +165,9 @@ public class ProfileHandlerTest extends BaseHandlerTest {
                                         .switchIfEmpty(Mono.just(Follow.builder().follow("success_test").build()));
 
         StepVerifier.create(followMono)
-                .assertNext(i -> {
-                    then(i.getFollow()).isEqualTo("success_test");
-                })
+                .assertNext(i ->
+                    then(i.getFollow()).isEqualTo("success_test")
+                )
                 .verifyComplete();
 
     }

--- a/src/test/java/com/donghun/reactiveblog/handler/UserHandlerTest.java
+++ b/src/test/java/com/donghun/reactiveblog/handler/UserHandlerTest.java
@@ -40,8 +40,8 @@ public class UserHandlerTest extends BaseHandlerTest {
 
     @BeforeEach
     public void init() {
-        userRepository.deleteAll();
-        tokenRepository.deleteAll();
+        userRepository.deleteAll().subscribe();
+        tokenRepository.deleteAll().subscribe();
     }
 
     @Test


### PR DESCRIPTION
- `Comment` 생성, 조회, 삭제 API 작성. (#18)

- `Comment` 도메인에 날짜 JSON 포맷 형식 설정 추가.

- `Comment` `API`를 작성하기 위해 CommentDTO, CommentPostVO, CommentVO, CommentsVO 객체 생성 및 테스트 코드 작성.

- 각 삭제를 처리하는 `API` 코드 일부 리팩토링.